### PR TITLE
update and rework check_mk plugins a bit to work with current speedtest cli 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The plug-in is divided into a client and a server plug-in. You can install the c
 3. Install apcalc - For Debian: `apt install apcalc -y`
 4. Save the `speedtest_agent_plugin.sh` on the client under the folder: `/usr/lib/check_mk_agent/plugins/`
 5. Make the script executable - `chmod +x /usr/lib/check_mk_agent/plugins/speedtest_server_plugin.py`
-6. Check on the client with the command: `check_mk_agent` if the script can be executed successfully. 
+6. Check on the client with the command: `check_mk_agent` if the script can be executed successfully. (output might be encrypted)
+7. Check that cache json file has been created: /var/lib/check_mk_agent/cache/speedtest_data.json
 
 ## Installation - STEP 2 - Installing the Server Plugin
 1. Switch to your CheckMK installation on your CheckMK server. `su - <mycheckmk>`
@@ -27,7 +28,7 @@ The plug-in is divided into a client and a server plug-in. You can install the c
 3. Make the script executable - `chmod +x speedtest_server_plugin.py`
 
 ## Installation - STEP 3 - Adding the service in CheckMK
-Now, after a service scan, a new service with the name: `Ookla Speed check` should appear in CheckMK under the respective client. Add this.
+Rediscover Services on the host. A new service with the name: `Ookla Speed check` should appear. Add it as a monitored Service.
 
 ## Increasing the check interval
 By default, the speed test is performed every 30 minutes. If you want to change this, you can do so in the client/agent plugin (`speedtest_agent_plugin.sh`). To do this, simply change the variable content of `speedtest_every_min` in the script. 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,13 @@
 ![image speedtest](https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Speedtest.net_logo.svg/2560px-Speedtest.net_logo.svg.png)
 
-# Check_MK DSL Check
+# Check_MK Speed Check
 
-This Check_MK plugin allows you to retrieve various information about your DSL. This includes the following:
+This Check_MK plugin allows you to retrieve various information about your Internet Speed. This includes the following:
 - Download/Mbps
 - Upload/Mbps
 - Average latency
-- Max latency
-- Min latency
-- Packet loss
 - Your public IP
 - The remote Server IP
-- The Speedtest result as HTML
 
 If required, this tool can also be extended with some additional information. For the speed tests, the service of ookla (https://www.speedtest.net/) is used.
 
@@ -22,16 +18,16 @@ The plug-in is divided into a client and a server plug-in. You can install the c
 2. Install the JSON Processor - For Debian: `apt install jq -y`
 3. Install apcalc - For Debian: `apt install apcalc -y`
 4. Save the `speedtest_agent_plugin.sh` on the client under the folder: `/usr/lib/check_mk_agent/plugins/`
-5. Make the script executable - `chmod 755 /usr/lib/check_mk_agent/plugins/speedtest_server_plugin.py`
+5. Make the script executable - `chmod +x /usr/lib/check_mk_agent/plugins/speedtest_server_plugin.py`
 6. Check on the client with the command: `check_mk_agent` if the script can be executed successfully. 
 
 ## Installation - STEP 2 - Installing the Server Plugin
 1. Switch to your CheckMK installation on your CheckMK server. `su - <mycheckmk>`
 2. Navigate to the Plugin folder Folder `cd local/lib/check_mk/base/plugins/agent_based`
-3. Make the script executable - `chmod 755 speedtest_server_plugin.py`
+3. Make the script executable - `chmod +x speedtest_server_plugin.py`
 
 ## Installation - STEP 3 - Adding the service in CheckMK
-Now, after a service scan, a new service with the name: `Ookla DSL check` should appear in CheckMK under the respective client. Add this.
+Now, after a service scan, a new service with the name: `Ookla Speed check` should appear in CheckMK under the respective client. Add this.
 
 ## Increasing the check interval
 By default, the speed test is performed every 30 minutes. If you want to change this, you can do so in the client/agent plugin (`speedtest_agent_plugin.sh`). To do this, simply change the variable content of `speedtest_every_min` in the script. 

--- a/speedtest_agent_plugin.sh
+++ b/speedtest_agent_plugin.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #This path can be changed as required
-data_filepath="/usr/lib/check_mk_agent/plugins/speedtest_data.json"
+data_filepath="/var/lib/check_mk_agent/cache/speedtest_data.json"
 
 start_speedtest=true
 speedtest_every_min=30
@@ -19,6 +19,7 @@ if [ "$start_speedtest" = true ]; then
     speedtest --json > $data_filepath
 fi
 
+###Json Example:
 #{
 #  "bytes_received": xxxxx,
 #  "bytes_sent": xxxxxx,
@@ -53,7 +54,6 @@ fi
 #  "timestamp": "yyyy-mm-ddTHH:MM:SS.SSSSST",
 #  "upload": xxxxxx.xxx
 #}
-
 
 # For simplicity, all variables were set in rows as follows
 download_mbps=$(calc -d print $(jq -c '.download' $data_filepath) / 1024 / 1024)

--- a/speedtest_agent_plugin.sh
+++ b/speedtest_agent_plugin.sh
@@ -4,7 +4,7 @@
 data_filepath="/usr/lib/check_mk_agent/plugins/speedtest_data.json"
 
 start_speedtest=true
-speedtest_every_min=5
+speedtest_every_min=30
 
 if [ -f "$data_filepath" ]; then
     time_diff=$(expr $(date +%s) - $(stat -c %Y $data_filepath))

--- a/speedtest_agent_plugin.sh
+++ b/speedtest_agent_plugin.sh
@@ -4,7 +4,7 @@
 data_filepath="/usr/lib/check_mk_agent/plugins/speedtest_data.json"
 
 start_speedtest=true
-speedtest_every_min=30
+speedtest_every_min=5
 
 if [ -f "$data_filepath" ]; then
     time_diff=$(expr $(date +%s) - $(stat -c %Y $data_filepath))
@@ -16,25 +16,56 @@ if [ -f "$data_filepath" ]; then
 fi
 
 if [ "$start_speedtest" = true ]; then
-    speedtest --accept-license --accept-gdpr -f json > $data_filepath
+    speedtest --json > $data_filepath
 fi
 
-# For simplicity, all variables were set in rows as follows
-download_mbps=$(calc print $(jq -c '.download.bandwidth' $data_filepath) / 125 / 1000)
-upload_mbps=$(calc print $(jq -c '.upload.bandwidth' $data_filepath) / 125 / 1000)
+#{
+#  "bytes_received": xxxxx,
+#  "bytes_sent": xxxxxx,
+#  "client": {
+#    "country": "xx",
+#    "ip": "xx.xx.xx.xx",
+#    "isp": "xxxx",
+#    "ispdlavg": "x",
+#    "isprating": "x.x",
+#    "ispulavg": "x",
+#    "lat": "xx.xxx",
+#    "loggedin": "x",
+#    "lon": "x.xxx",
+#    "rating": "x"
+#  },
+#  "download": xxxxxx.xxx,
+#  "ping": x.xxx,
+#  "server": {
+#    "cc": "xx",
+#    "country": "xxxxx",
+#    "d": xx.xxxxxxx,
+#    "host": "url:port",
+#    "id": "xxxx",
+#    "lat": "xx.xxxx",
+#    "latency": x.xxx,
+#    "lon": "x.xxx",
+#    "name": "xxxxx",
+#    "sponsor": "xxxxx",
+#    "url": "http://xxxxxx:port/xxxx"
+#  },
+#  "share": null,
+#  "timestamp": "yyyy-mm-ddTHH:MM:SS.SSSSST",
+#  "upload": xxxxxx.xxx
+#}
 
-latency_average=$(jq -c '.ping.latency' $data_filepath)
-latency_lowest=$(jq -c '.ping.low' $data_filepath)
-latency_highest=$(jq -c '.ping.high' $data_filepath)
-packet_loss=$(jq -c '.packetLoss' $data_filepath)
-local_public_ip=$(jq -c '.interface.externalIp' $data_filepath)
-remote_server_ip=$(jq -c '.server.ip' $data_filepath)
-result_url=$(jq -c '.result.url' $data_filepath)
+
+# For simplicity, all variables were set in rows as follows
+download_mbps=$(calc -d print $(jq -c '.download' $data_filepath) / 1024 / 1024)
+upload_mbps=$(calc -d print $(jq -c '.upload' $data_filepath) / 1024 / 1024)
+
+latency_average=$(jq -c '.ping' $data_filepath)
+local_public_ip=$(jq -c '.client.ip' $data_filepath)
+remote_server_ip=$(jq -c '.server.host' $data_filepath)
+
 
 # CheckMK uses/reads the following output
-echo "<<<ookla_dsl_check>>>"
+echo "<<<ookla_speed_check>>>"
 echo "Download_Mbps=${download_mbps} Upload_Mbps=${upload_mbps} "`
-    `"Latency_average_ms=${latency_average} Latency_lowest_ms=${latency_lowest} "`
-    `"Latency_highest_ms=${latency_highest} Packet_loss=${packet_loss} "`
-    `"Local_public_ip=${local_public_ip} Remote_server_ip=${remote_server_ip} "`
-    `"Result_url=${result_url}"
+    `"Latency_average_ms=${latency_average} "`
+    `"Local_public_ip=${local_public_ip} Remote_server_ip=${remote_server_ip} "

--- a/speedtest_server_plugin.py
+++ b/speedtest_server_plugin.py
@@ -21,14 +21,13 @@ def check_speedtest_plugin(section):
         try:
             yield Result(
                 state=State.OK,
-                summary=f"{query[0]}Mbps/{query[1]}Mbps",
-                details=f"Local IP: {query[6]}, Remote IP: {query[7]},"
-                + f" Result URL: {query[8]} ",
+                summary=f"{query[0]} Mbps, {query[1]} Mbps",
+                details=f"Ping: {query[2]}, Local IP: {query[3]}, Remote IP: {query[4]}",
             )
         except Exception as e:
             yield Result(
                 state=State.CRIT,
-                summary="THE SPEED TEST DATA COULD NOT BE READ OUT CORRECTLY!",
+                summary="THE SPEED22 TEST DATA COULD NOT BE READ OUT CORRECTLY!",
                 details=f"ERROR: {e}",
             )
 
@@ -38,8 +37,8 @@ def check_speedtest_plugin(section):
 
 
 register.check_plugin(
-    name="ookla_dsl_check",
-    service_name="Ookla DSL check",
+    name="ookla_speed_check",
+    service_name="Ookla Speed check",
     discovery_function=discover_speedtest_plugin,
     check_function=check_speedtest_plugin,
 )


### PR DESCRIPTION
speedtest_agent_plugin:
- renamed plugin from "dsl" to "speed" since the word "dsl" is a product name and not a measurement
- OKLA Speedtest CLI seems to have changed what they print into the json. 
- Changed json output location to /var/lib/check_mk_agent/cache/ folder
- Changed speed measurements to be in Mbps not KBps (could be side effect from OKLA Spedtest CLI change)
- removed no longer available ping-lowest/highest / packageless variables
- removed result url variable
- added json output example

speedtest_server_plugin
- renamed plugin from "dsl" to "speed" since the word "dsl" is a product name and not a measurement
- removed the now missing variables

README.md:
- renamed plugin from "dsl" to "speed" since the word "dsl" is a product name and not a measurement
- updated wording a bit
- removed chmod 755 and replaced it with chmod +x instead.